### PR TITLE
修复双击在已放大的情况下仍然放大的问题

### DIFF
--- a/library/src/main/java/com/bm/library/PhotoView.java
+++ b/library/src/main/java/com/bm/library/PhotoView.java
@@ -911,13 +911,25 @@ public class PhotoView extends ImageView {
             mTranslateY = 0;
 
             if (isZoonUp) {
-                from = mScale;
-                to = 1;
+                if (mScale == 1){
+                    isZoonUp = false;
+                    from = mScale;
+                    to = mMaxScale;
+                    mScaleCenter.set(e.getX(), e.getY());
+                }else {
+                    from = mScale;
+                    to = 1;
+                }
             } else {
-                from = mScale;
-                to = mMaxScale;
-
-                mScaleCenter.set(e.getX(), e.getY());
+                if (mScale == mMaxScale){
+                    isZoonUp = true;
+                    from = mScale;
+                    to = 1;
+                }else {
+                    from = mScale;
+                    to = mMaxScale;
+                    mScaleCenter.set(e.getX(), e.getY());
+                }
             }
 
             mTmpMatrix.reset();


### PR DESCRIPTION
在图片已经手动拉到最大的时候，这时候双击仍然会放大，已添加相关代码