### PR TITLE
修复setOnLongClickListener用不了

### DIFF
--- a/library/src/main/java/com/bm/library/PhotoView.java
+++ b/library/src/main/java/com/bm/library/PhotoView.java
@@ -153,6 +153,7 @@ public class PhotoView extends ImageView {
 
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
+        super.setOnLongClickListener(l); 
         mLongClick = l;
     }
 


### PR DESCRIPTION
今天更新了一下陈年老app，发现长按不好使了，调试了好久才发现这缺了一行代码
少了这行代码setOnLongClickListener直接不能用了。